### PR TITLE
fix: ignore ...args:any[] errors with no-explicit-any

### DIFF
--- a/src/typescript.js
+++ b/src/typescript.js
@@ -53,6 +53,10 @@ module.exports = {
           "error",
           { allowAny: true },
         ],
+        "@typescript-eslint/no-explicit-any": [
+          "error",
+          { ignoreRestArgs: true },
+        ],
       },
       settings: {
         "import/resolver": { typescript: {} },


### PR DESCRIPTION
In the case of function types, this will ignore the use of `any` which cannot be worked around.

```typescript
function <T extends (...args: any[])>(fn: T) {}
```

It also raises this warning to an error.

I'll also be opening an issue in the TS eslint repo to ignore `catch` clauses.