### PR TITLE
feat: no-require-assign plugin

### DIFF
--- a/modules/no-require-assign/.eslintrc.js
+++ b/modules/no-require-assign/.eslintrc.js
@@ -1,0 +1,19 @@
+"use strict";
+
+module.exports = {
+  root: true,
+  extends: [
+    "eslint:recommended",
+    "plugin:eslint-plugin/recommended",
+    "plugin:node/recommended",
+  ],
+  env: {
+    node: true,
+  },
+  overrides: [
+    {
+      files: ["tests/**/*.js"],
+      env: { mocha: true },
+    },
+  ],
+};

--- a/modules/no-require-assign/.npmrc
+++ b/modules/no-require-assign/.npmrc
@@ -1,0 +1,1 @@
+package-lock = false

--- a/modules/no-require-assign/README.md
+++ b/modules/no-require-assign/README.md
@@ -1,0 +1,41 @@
+# eslint-plugin-no-require-assign
+
+Disallow assigning to required bindings
+
+## Installation
+
+You'll first need to install [ESLint](https://eslint.org/):
+
+```sh
+npm i eslint --save-dev
+```
+
+Next, install `eslint-plugin-no-require-assign`:
+
+```sh
+npm install eslint-plugin-no-require-assign --save-dev
+```
+
+## Usage
+
+Add `no-require-assign` to the plugins section of your `.eslintrc` configuration file. You can omit the `eslint-plugin-` prefix:
+
+```json
+{
+  "plugins": ["no-require-assign"]
+}
+```
+
+Then configure the rules you want to use under the rules section.
+
+```json
+{
+  "rules": {
+    "no-require-assign/rule-name": 2
+  }
+}
+```
+
+## Supported Rules
+
+- Fill in provided rules here

--- a/modules/no-require-assign/lib/index.js
+++ b/modules/no-require-assign/lib/index.js
@@ -1,0 +1,11 @@
+/**
+ * @fileoverview Disallow assigning to required bindings
+ * @author Chia Wei
+ */
+"use strict";
+
+module.exports = {
+    rules: {
+        'no-require-assign': require('./rules/no-require-assign')
+    }
+}

--- a/modules/no-require-assign/lib/rules/no-require-assign.js
+++ b/modules/no-require-assign/lib/rules/no-require-assign.js
@@ -1,0 +1,216 @@
+/**
+ * @fileoverview Rule to flag updates of imported bindings. Originally from no-import-assign.
+ * @author Chia Wei <https://github.com/weiliddat>
+ * @credit Toru Nagashima <https://github.com/mysticatea>
+ * @license MIT (https://github.com/eslint/eslint/blob/main/LICENSE)
+ */
+
+"use strict";
+
+// ------------------------------------------------------------------------------
+// Helpers
+// ------------------------------------------------------------------------------
+
+const { findVariable } = require("eslint-utils");
+const { skipChainExpression, isSpecificMemberAccess } = require("./utils/ast-utils");
+
+const WellKnownMutationFunctions = {
+	Object: /^(?:assign|definePropert(?:y|ies)|freeze|setPrototypeOf)$/u,
+	Reflect: /^(?:(?:define|delete)Property|set(?:PrototypeOf)?)$/u,
+};
+
+/**
+ * Check if a given node is LHS of an assignment node.
+ * @param {ASTNode} node The node to check.
+ * @returns {boolean} `true` if the node is LHS.
+ */
+function isAssignmentLeft(node) {
+	const { parent } = node;
+
+	return (
+		(parent.type === "AssignmentExpression" && parent.left === node) ||
+		// Destructuring assignments
+		parent.type === "ArrayPattern" ||
+		(parent.type === "Property" &&
+			parent.value === node &&
+			parent.parent.type === "ObjectPattern") ||
+		parent.type === "RestElement" ||
+		(parent.type === "AssignmentPattern" && parent.left === node)
+	);
+}
+
+/**
+ * Check if a given node is the operand of mutation unary operator.
+ * @param {ASTNode} node The node to check.
+ * @returns {boolean} `true` if the node is the operand of mutation unary operator.
+ */
+function isOperandOfMutationUnaryOperator(node) {
+	const argumentNode =
+		node.parent.type === "ChainExpression" ? node.parent : node;
+	const { parent } = argumentNode;
+
+	return (
+		(parent.type === "UpdateExpression" &&
+			parent.argument === argumentNode) ||
+		(parent.type === "UnaryExpression" &&
+			parent.operator === "delete" &&
+			parent.argument === argumentNode)
+	);
+}
+
+/**
+ * Check if a given node is the iteration variable of `for-in`/`for-of` syntax.
+ * @param {ASTNode} node The node to check.
+ * @returns {boolean} `true` if the node is the iteration variable.
+ */
+function isIterationVariable(node) {
+	const { parent } = node;
+
+	return (
+		(parent.type === "ForInStatement" && parent.left === node) ||
+		(parent.type === "ForOfStatement" && parent.left === node)
+	);
+}
+
+/**
+ * Check if a given node is at the first argument of a well-known mutation function.
+ * - `Object.assign`
+ * - `Object.defineProperty`
+ * - `Object.defineProperties`
+ * - `Object.freeze`
+ * - `Object.setPrototypeOf`
+ * - `Reflect.defineProperty`
+ * - `Reflect.deleteProperty`
+ * - `Reflect.set`
+ * - `Reflect.setPrototypeOf`
+ * @param {ASTNode} node The node to check.
+ * @param {Scope} scope A `escope.Scope` object to find variable (whichever).
+ * @returns {boolean} `true` if the node is at the first argument of a well-known mutation function.
+ */
+function isArgumentOfWellKnownMutationFunction(node, scope) {
+	const { parent } = node;
+
+	if (parent.type !== "CallExpression" || parent.arguments[0] !== node) {
+		return false;
+	}
+	const callee = skipChainExpression(parent.callee);
+
+	if (
+		!isSpecificMemberAccess(
+			callee,
+			"Object",
+			WellKnownMutationFunctions.Object
+		) &&
+		!isSpecificMemberAccess(
+			callee,
+			"Reflect",
+			WellKnownMutationFunctions.Reflect
+		)
+	) {
+		return false;
+	}
+	const variable = findVariable(scope, callee.object);
+
+	return variable !== null && variable.scope.type === "global";
+}
+
+/**
+ * Check if the identifier node is placed at to update members.
+ * @param {ASTNode} id The Identifier node to check.
+ * @param {Scope} scope A `escope.Scope` object to find variable (whichever).
+ * @returns {boolean} `true` if the member of `id` was updated.
+ */
+function isMemberWrite(id, scope) {
+	const { parent } = id;
+
+	return (
+		(parent.type === "MemberExpression" &&
+			parent.object === id &&
+			(isAssignmentLeft(parent) ||
+				isOperandOfMutationUnaryOperator(parent) ||
+				isIterationVariable(parent))) ||
+		isArgumentOfWellKnownMutationFunction(id, scope)
+	);
+}
+
+/**
+ * Get the mutation node.
+ * @param {ASTNode} id The Identifier node to get.
+ * @returns {ASTNode} The mutation node.
+ */
+function getWriteNode(id) {
+	let node = id.parent;
+
+	while (
+		node &&
+		node.type !== "AssignmentExpression" &&
+		node.type !== "UpdateExpression" &&
+		node.type !== "UnaryExpression" &&
+		node.type !== "CallExpression" &&
+		node.type !== "ForInStatement" &&
+		node.type !== "ForOfStatement"
+	) {
+		node = node.parent;
+	}
+
+	return node || id;
+}
+
+// ------------------------------------------------------------------------------
+// Rule Definition
+// ------------------------------------------------------------------------------
+
+module.exports = {
+	meta: {
+		type: "problem",
+
+		docs: {
+			description: "Disallow assigning to required bindings",
+			recommended: true,
+		},
+
+		schema: [],
+
+		messages: {
+			readonly: "'{{name}}' is read-only.",
+			readonlyMember: "The members of '{{name}}' are read-only.",
+		},
+	},
+
+	create(context) {
+		return {
+			CallExpression(node) {
+				if (node.callee.name === "require") {
+					const scope = context.getScope();
+
+					for (const variable of context.getDeclaredVariables(
+						node.parent
+					)) {
+						const referencesWithoutOriginalDeclaration =
+							variable.references.filter(
+								(r) => r.writeExpr !== node
+							);
+
+						for (const reference of referencesWithoutOriginalDeclaration) {
+							if (reference.isWrite()) {
+								context.report({
+									node: getWriteNode(reference.identifier),
+									messageId: "readonly",
+									data: { name: reference.identifier.name },
+								});
+							} else if (
+								isMemberWrite(reference.identifier, scope)
+							) {
+								context.report({
+									node: getWriteNode(reference.identifier),
+									messageId: "readonlyMember",
+									data: { name: reference.identifier.name },
+								});
+							}
+						}
+					}
+				}
+			},
+		};
+	},
+};

--- a/modules/no-require-assign/lib/rules/utils/ast-utils.js
+++ b/modules/no-require-assign/lib/rules/utils/ast-utils.js
@@ -1,0 +1,127 @@
+/**
+ * Copied from eslint/lib/rules/utils/ast-utils because it's not exported
+ * @author Gyandeep Singh
+ * @license MIT (https://github.com/eslint/eslint/blob/main/LICENSE)
+ */
+
+function skipChainExpression(node) {
+	return node && node.type === "ChainExpression" ? node.expression : node;
+}
+
+function isSpecificMemberAccess(node, objectName, propertyName) {
+	const checkNode = skipChainExpression(node);
+
+	if (checkNode.type !== "MemberExpression") {
+		return false;
+	}
+
+	if (objectName && !isSpecificId(checkNode.object, objectName)) {
+		return false;
+	}
+
+	if (propertyName) {
+		const actualPropertyName = getStaticPropertyName(checkNode);
+
+		if (
+			typeof actualPropertyName !== "string" ||
+			!checkText(actualPropertyName, propertyName)
+		) {
+			return false;
+		}
+	}
+
+	return true;
+}
+
+function isSpecificId(node, name) {
+	return node.type === "Identifier" && checkText(node.name, name);
+}
+
+function checkText(actual, expected) {
+	return typeof expected === "string"
+		? actual === expected
+		: expected.test(actual);
+}
+
+function getStaticPropertyName(node) {
+	let prop;
+
+	switch (node && node.type) {
+		case "ChainExpression":
+			return getStaticPropertyName(node.expression);
+
+		case "Property":
+		case "PropertyDefinition":
+		case "MethodDefinition":
+			prop = node.key;
+			break;
+
+		case "MemberExpression":
+			prop = node.property;
+			break;
+
+		// no default
+	}
+
+	if (prop) {
+		if (prop.type === "Identifier" && !node.computed) {
+			return prop.name;
+		}
+
+		return getStaticStringValue(prop);
+	}
+
+	return null;
+}
+
+function getStaticStringValue(node) {
+	switch (node.type) {
+		case "Literal":
+			if (node.value === null) {
+				if (isNullLiteral(node)) {
+					return String(node.value); // "null"
+				}
+				if (node.regex) {
+					return `/${node.regex.pattern}/${node.regex.flags}`;
+				}
+				if (node.bigint) {
+					return node.bigint;
+				}
+
+				// Otherwise, this is an unknown literal. The function will return null.
+			} else {
+				return String(node.value);
+			}
+			break;
+		case "TemplateLiteral":
+			if (node.expressions.length === 0 && node.quasis.length === 1) {
+				return node.quasis[0].value.cooked;
+			}
+			break;
+
+		// no default
+	}
+
+	return null;
+}
+
+function isNullLiteral(node) {
+	/*
+	 * Checking `node.value === null` does not guarantee that a literal is a null literal.
+	 * When parsing values that cannot be represented in the current environment (e.g. unicode
+	 * regexes in Node 4), `node.value` is set to `null` because it wouldn't be possible to
+	 * set `node.value` to a unicode regex. To make sure a literal is actually `null`, check
+	 * `node.regex` instead. Also see: https://github.com/eslint/eslint/issues/8020
+	 */
+	return (
+		node.type === "Literal" &&
+		node.value === null &&
+		!node.regex &&
+		!node.bigint
+	);
+}
+
+module.exports = {
+	skipChainExpression,
+	isSpecificMemberAccess,
+};

--- a/modules/no-require-assign/package.json
+++ b/modules/no-require-assign/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "eslint-plugin-no-require-assign",
+  "version": "1.0.0",
+  "description": "Disallow assigning to required bindings",
+  "keywords": [
+    "eslint",
+    "eslintplugin",
+    "eslint-plugin"
+  ],
+  "author": "Chia Wei",
+  "main": "./lib/index.js",
+  "exports": "./lib/index.js",
+  "scripts": {
+    "lint": "eslint .",
+    "test": "mocha tests --recursive"
+  },
+  "devDependencies": {
+    "eslint": "^8.22.0",
+    "eslint-plugin-eslint-plugin": "^5.0.0",
+    "eslint-plugin-node": "^11.1.0",
+    "mocha": "^10.0.0"
+  },
+  "engines": {
+    "node": "^14.17.0 || ^16.0.0 || >= 18.0.0"
+  },
+  "peerDependencies": {
+    "eslint": ">=8",
+    "eslint-utils": ">=3"
+  },
+  "license": "MIT"
+}

--- a/modules/no-require-assign/tests/lib/rules/no-require-assign.js
+++ b/modules/no-require-assign/tests/lib/rules/no-require-assign.js
@@ -1,0 +1,144 @@
+/**
+ * @fileoverview Tests for no-require-assign rule.
+ * @author Chia Wei <https://github.com/weiliddat>
+ * @credit Toru Nagashima <https://github.com/mysticatea>
+ * @license MIT (https://github.com/eslint/eslint/blob/main/LICENSE)
+ */
+
+"use strict";
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+const rule = require("../../../lib/rules/no-require-assign");
+const { RuleTester } = require("eslint");
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+const ruleTester = new RuleTester({
+	parserOptions: {
+		ecmaVersion: 2018,
+		sourceType: "module",
+	},
+	globals: {
+		Reflect: "readonly",
+	},
+});
+
+ruleTester.run("no-require-assign", rule, {
+	valid: [
+		"const mod = require('mod');",
+		"const mod = require('mod'); const b = mod",
+		"const mod = require('mod'); const b = mod.foo",
+		"const mod = copy(require('mod')); mod = 0",
+		"const mod = copy(require('mod')); mod.foo = 0",
+	],
+	invalid: [
+		{
+			code: "const mod1 = require('mod'); mod1 = 0",
+			errors: [
+				{ messageId: "readonly", data: { name: "mod1" }, column: 30 },
+			],
+		},
+		{
+			code: "const mod2 = require('mod'); mod2 += 0",
+			errors: [
+				{ messageId: "readonly", data: { name: "mod2" }, column: 30 },
+			],
+		},
+		{
+			code: "const mod3 = require('mod'); mod3++",
+			errors: [
+				{ messageId: "readonly", data: { name: "mod3" }, column: 30 },
+			],
+		},
+		{
+			code: "const mod4 = require('mod'); for (mod4 in foo);",
+			errors: [
+				{ messageId: "readonly", data: { name: "mod4" }, column: 30 },
+			],
+		},
+		{
+			code: "const mod5 = require('mod'); for (mod5 of foo);",
+			errors: [
+				{ messageId: "readonly", data: { name: "mod5" }, column: 30 },
+			],
+		},
+		{
+			code: "const mod6 = require('mod'); mod6.foo = 0",
+			errors: [
+				{
+					messageId: "readonlyMember",
+					data: { name: "mod6" },
+					column: 30,
+				},
+			],
+		},
+		{
+			code: "const {named1} = require('mod'); named1 = 0",
+			errors: [
+				{ messageId: "readonly", data: { name: "named1" }, column: 34 },
+			],
+		},
+		{
+			code: "const {named2} = require('mod'); named2 += 0",
+			errors: [
+				{ messageId: "readonly", data: { name: "named2" }, column: 34 },
+			],
+		},
+		{
+			code: "const {named3} = require('mod'); named3++",
+			errors: [
+				{ messageId: "readonly", data: { name: "named3" }, column: 34 },
+			],
+		},
+		{
+			code: "const {named4} = require('mod'); named4.foo = 0",
+			errors: [
+				{
+					messageId: "readonlyMember",
+					data: { name: "named4" },
+					column: 34,
+				},
+			],
+		},
+
+		// Optional chaining
+		{
+			code: "const mod = require('mod'); Object?.defineProperty(mod, key, d)",
+			parserOptions: { ecmaVersion: 2020 },
+			errors: [
+				{
+					messageId: "readonlyMember",
+					data: { name: "mod" },
+					column: 29,
+				},
+			],
+		},
+		{
+			code: "const mod = require('mod'); (Object?.defineProperty)(mod, key, d)",
+			parserOptions: { ecmaVersion: 2020 },
+			errors: [
+				{
+					messageId: "readonlyMember",
+					data: { name: "mod" },
+					column: 29,
+				},
+			],
+		},
+		{
+			code: "const mod = require('mod'); delete mod?.prop",
+			parserOptions: { ecmaVersion: 2020 },
+			errors: [
+				{
+					messageId: "readonlyMember",
+					data: { name: "mod" },
+					column: 29,
+				},
+			],
+		},
+	],
+});

--- a/package.json
+++ b/package.json
@@ -23,6 +23,9 @@
     "type": "git",
     "url": "https://github.com/parcelLab/eslint-config.git"
   },
+  "dependencies": {
+    "eslint-plugin-no-require-assign": "file:modules/no-require-assign"
+  },
   "devDependencies": {
     "@commitlint/cli": "17.0.3",
     "@commitlint/config-conventional": "17.0.3",

--- a/src/base.js
+++ b/src/base.js
@@ -7,7 +7,7 @@ module.exports = {
     node: true,
     es2022: true,
   },
-  plugins: ["unicorn", "promise"],
+  plugins: ["unicorn", "promise", "no-require-assign"],
   extends: [
     "eslint:recommended",
     "plugin:import/recommended",


### PR DESCRIPTION
Am unsure if we want to just provide the plugin through `eslint-config`, and let users opt-in to the `no-require-assign` rule, or make it part of the base rules `base.js`.

For Backend we'll have to opt it in anyways since it has its own base config, and `eslint-config` is only an override for specific folders.

I'm for just keeping it optional for now and just providing the plugin and not the rule through `base.js`.
