### PR TITLE
fix(base): remove allowed abbreviations from the not allowed list

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@parcellab/eslint-config",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Specific parcelLab configuration for JavaScript and TypeScript projects",
   "main": "index.js",
   "exports": {

--- a/src/base.js
+++ b/src/base.js
@@ -34,44 +34,36 @@ module.exports = {
           addr: { address: true },
           alloc: { allocation: true },
           alt: { alternative: true },
-          app: { application: true },
           apiRes: { apiResponse: true },
-          auth: { authentication: true },
           avg: { average: true },
           bg: { background: true },
           bin: { binary: true },
           buf: { buffer: true },
-          char: { character: true },
           calc: { calculation: true },
           cert: { certificate: true },
           cfg: { configuration: true },
           ch: { channel: true },
-          cmd: { command: true },
+          char: { character: true },
           cmp: { compare: true },
           cnt: { counter: true },
           col: { column: true },
           coord: { coordinate: true },
           ctrl: { control: true },
           diff: { difference: true },
-          expr: { expression: true },
           fmt: { format: true },
           gen: { generate: true },
           hdr: { header: true },
           hw: { hardware: true },
-          id: { identifier: true },
           img: { image: true },
           info: { information: true },
           init: { initialization: true },
           k: { key: true },
           lang: { language: true },
           lat: { latitude: true },
-          lib: { library: true },
           lon: { longitude: true },
           math: { mathematics: true },
-          max: { maximum: true },
           mem: { memory: true },
           mid: { middle: true },
-          min: { minimum: true },
           misc: { miscellaneous: true },
           net: { network: true },
           op: { operation: true },
@@ -86,11 +78,11 @@ module.exports = {
           rand: { random: true },
           recv: { receive: true },
           rng: { range: true },
-          sem: { semaphore: true },
           sel: { selection: true },
+          sem: { semaphore: true },
           seq: { sequence: true },
-          stat: { statistic: true },
           sqrt: { squareRoot: true },
+          stat: { statistic: true },
           ts: { timestamp: true },
         },
         allowList: {
@@ -132,9 +124,9 @@ module.exports = {
           num: true, // number
           obj: true, // object
           opts: true, // options
-          pkg: true, // package
           param: true, // parameter
           params: true, // parameters
+          pkg: true, // package
           prev: true, // previous
           prod: true, // production
           prop: true, // property

--- a/test/configs.spec.ts
+++ b/test/configs.spec.ts
@@ -1,23 +1,18 @@
 import { ESLint } from "eslint";
 import { exec } from "node:child_process";
-
-function execPromise(command: string) {
-  return new Promise((resolve, reject) => {
-    exec(command, (error, stdout, _) => {
-      if (error) reject(error);
-      else resolve(stdout);
-    });
-  });
-}
+import { promisify } from "node:util";
 
 async function lintFile(configFile: string, fileToLint: string) {
-  const lintResult = await execPromise(`eslint \
+  const eslintCommand = `eslint \
     --format=json \
     --config ${configFile} \
     --no-ignore \
-    ${fileToLint}`);
+    ${fileToLint}`;
 
-  return JSON.parse(String(lintResult)) as ESLint.LintResult[];
+  const execPromisified = promisify(exec);
+  const lintResult = await execPromisified(eslintCommand);
+
+  return JSON.parse(String(lintResult.stdout)) as ESLint.LintResult[];
 }
 
 describe("Validate ESLint configs", () => {


### PR DESCRIPTION
Please, ignore this change if this duplication is intentional!

This PR removes the allowed abbreviated words: `app`, `auth`, `expr`, `id`, `lib`, `max`, and `min`, from the list of not allowed abbreviations.

I think that these words are in the blocked list just by mistake because they exist on the allowed list.