### PR TITLE
feat(react): allow `console` for React

### DIFF
--- a/src/react.js
+++ b/src/react.js
@@ -20,9 +20,10 @@ module.exports = {
       ],
       plugins: ["react"],
       rules: {
+        "no-console": ["error", { allow: ["warn", "error"] }],
         "react/function-component-definition": [
           "error",
-          { namedComponents: "arrow-function" },
+          { namedComponents: "function-declaration" },
         ],
         "no-restricted-syntax": [
           "error",

--- a/test/fixtures/react-file.jsx
+++ b/test/fixtures/react-file.jsx
@@ -5,7 +5,7 @@ function emptyListMessage() {
   return "No items";
 }
 
-export const SampleComponent = () => {
+export function SampleComponent() {
   const fruits = ["apple", "banana", "orange"];
   const listTitles = ["sample"];
 
@@ -30,4 +30,4 @@ export const SampleComponent = () => {
       </div>
     </div>
   );
-};
+}

--- a/test/fixtures/react-file.tsx
+++ b/test/fixtures/react-file.tsx
@@ -6,7 +6,7 @@ function emptyListMessage() {
   return "No items";
 }
 
-export const SampleComponent = (): JSX.Element => {
+export function SampleComponent(): JSX.Element {
   const fruits = ["apple", "banana", "orange"];
   const listTitles = ["sample"];
 
@@ -31,4 +31,4 @@ export const SampleComponent = (): JSX.Element => {
       </div>
     </div>
   );
-};
+}


### PR DESCRIPTION
In React projects is common that we want to throw some errors message to the console, normally for some edge cases or messages for the developer that is using our code.

This change, allows the use of `console.warn` and `console.error`.