### PR TITLE
style: allow err as error variable in catch

### DIFF
--- a/src/base.js
+++ b/src/base.js
@@ -17,14 +17,20 @@ module.exports = {
   ],
   rules: {
     "promise/catch-or-return": ["error", { allowFinally: true }],
-    "unicorn/no-array-for-each": "off",
-    "unicorn/no-null": "off",
-    "unicorn/prefer-spread": "off",
-    "unicorn/prefer-number-properties": "off",
-    "unicorn/numeric-separators-style": "off",
-    "unicorn/no-await-expression-member": "off",
+    "unicorn/catch-error-name": [
+      "error",
+      {
+        ignore: ["^error\\d*$", "^err\\d*$"],
+      },
+    ],
     "@typescript-eslint/ban-ts-comment": "off",
     "unicorn/import-style": "off",
+    "unicorn/no-array-for-each": "off",
+    "unicorn/no-await-expression-member": "off",
+    "unicorn/no-null": "off",
+    "unicorn/numeric-separators-style": "off",
+    "unicorn/prefer-number-properties": "off",
+    "unicorn/prefer-spread": "off",
     "unicorn/prevent-abbreviations": [
       "off",
       {


### PR DESCRIPTION
Most probably many people have stumbled about this problem:

![Screenshot 2023-03-10 at 10 01 46](https://user-images.githubusercontent.com/1042520/224271892-676321d7-fd03-49ea-9640-2eacef10770b.png)

It is quite typical to set `err` as a variable name for such clauses. What if we just allow `err` as well? Therefore, `error` and `err` will be ok to use in this context.