### PR TITLE
chore: add .cjs override to base config

### DIFF
--- a/src/base.js
+++ b/src/base.js
@@ -185,7 +185,7 @@ module.exports = {
     },
     {
       /**
-       * Include other file extensions other than the default ones
+       * Include other file extensions other than the .js
        */
       files: ["**/*.cjs"],
     },

--- a/src/base.js
+++ b/src/base.js
@@ -183,5 +183,11 @@ module.exports = {
         "unicorn/prefer-module": "off",
       },
     },
+    {
+      /**
+       * Include other file extensions other than the default ones
+       */
+      files: ["**/*.cjs"],
+    },
   ],
 };


### PR DESCRIPTION
Including .cjs file extension to the base lint configuration in order to automatically pick `*.cjs` files when linting, without the need to add a manual override in the project's eslint config.

## Description
I noticed that the files within our project's root folder were not automatically being checked when we run the `eslint .`. 
It seems that by default, eslint will just look for `.js` files (https://eslint.org/docs/latest/use/configure/configuration-files#specifying-target-files-to-lint).

We have already other configs with overrides to also include .ts(x), .test.*, etc files, but they do not include (.cjs).

So with this change it should also include .cjs files and you get that by using anything that extends the base config.

Test Before change:
<img width="1003" alt="Screenshot 2023-03-27 at 12 33 13" src="https://user-images.githubusercontent.com/25816956/227918747-b50bc88d-f9a1-4b6d-9d09-e80d64d330e2.png">

Test After Change:
<img width="1123" alt="Screenshot 2023-03-27 at 12 33 27" src="https://user-images.githubusercontent.com/25816956/227918797-08494f4f-8b81-4123-89f0-eb5debefc8ed.png">
 
## Checklist

- [ ] My change requires a change to the documentation **N/A**
- [ ] I have updated the documentation accordingly **N/A**
