### PR TITLE
fix: update react config to target both ts and tsx

### DIFF
--- a/src/react-ts.js
+++ b/src/react-ts.js
@@ -7,7 +7,7 @@ module.exports = {
   extends: [require.resolve("./react.js"), require.resolve("./typescript.js")],
   overrides: [
     {
-      files: ["*.tsx"],
+      files: ["*.ts?(x)"],
       extends: ["airbnb-typescript", "prettier"],
       rules: {
         "react/require-default-props": "off",

--- a/src/react.js
+++ b/src/react.js
@@ -11,7 +11,7 @@ module.exports = {
   extends: require.resolve("./base.js"),
   overrides: [
     {
-      files: ["*.jsx", "*.tsx"],
+      files: ["*.jsx", "*.ts?(x)"],
       extends: [
         "airbnb",
         "airbnb/hooks",


### PR DESCRIPTION
<!--- Provide a general summary of your changes -->
<!--- Write the related JIRA issue here with the [PROJ-123] format if applicable -->
<!--- If suggesting a new feature or change, please discuss it in the issue first -->

## Description

In react (typescript) projects we also need to apply linting to files that have the `.ts` extension, they might not export JSX code but e.g. hooks

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
